### PR TITLE
Deprecate run_as_secondary and run_as_primary. Add run_as_main.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asyncgui"
-version = "0.6.2"
+version = "0.6.3.dev0"
 description = "A thin layer that helps to wrap a callback-style API in an async/await-style API"
 authors = ["Nattōsai Mitō <flow4re2c@gmail.com>"]
 license = "MIT"

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -71,7 +71,7 @@ def modify_signature(app, what: str, name: str, obj, options, signature, return_
                      group1={'CancelScope', 'Nursery', 'TaskState', 'Task.cancel', 'Task.close', },
                      group2={'current_task', 'sleep_forever', 'open_nursery', },
                      # group3={"TaskState." + s for s in "CREATED STARTED CANCELLED FINISHED".split()},
-                     group4={'wait_all_cm', 'wait_any_cm', 'run_as_secondary', 'run_as_primary', 'run_as_daemon', },
+                     group4={'wait_all_cm', 'wait_any_cm', 'run_as_daemon', 'run_as_main', },
                      group5={'open_nursery', },
                      ):
     if not name.startswith(prefix):

--- a/sphinx/reference.rst
+++ b/sphinx/reference.rst
@@ -5,3 +5,4 @@ API Reference
    :members:
    :undoc-members:
    :no-show-inheritance:
+   :exclude-members: and_, or_, run_as_primary, run_as_secondary

--- a/sphinx/structured-concurrency-ja.rst
+++ b/sphinx/structured-concurrency-ja.rst
@@ -165,8 +165,8 @@ wait_any_cm, wait_all_cm
             ...
 
 
-run_as_secondary, run_as_daemon
--------------------------------
+run_as_daemon
+-------------
 
 これまで解説してきたAPIはどれも並行させたタスク達の関係が対等でした。
 ``wait_any_cm`` を例に挙げるならwithブロック内のコードと ``wait_any_cm`` に渡したタスクのどちらが完了した場合でももう片方を中断させるの
@@ -182,17 +182,18 @@ run_as_secondary, run_as_daemon
 withブロック内の完了を待つだけです。例えるなら非daemonスレッドとdaemonスレッドの関係です。withブロック内のコードが非daemonで
 ``async_fn()`` がdaemonになっていると考えて下さい。
 
-また ``run_as_daemon`` は ``run_as_secondary`` の別名となっています。
+.. note::
 
+    これは :func:`trio_util.run_and_cancelling` に相当する機能です。
 
-run_as_primary
---------------
+run_as_main
+-----------
 
 これは ``run_as_daemon`` の逆でwithブロック内がdaemonとなります。
 
 .. code-block::
 
-    async with run_as_primary(async_fn()) as primary_task:
+    async with run_as_main(async_fn()) as primary_task:
         ...
 
 すなわちwithブロック内が先に完了した場合は ``async_fn()`` の完了を待つ事になり、

--- a/sphinx/structured-concurrency.rst
+++ b/sphinx/structured-concurrency.rst
@@ -125,8 +125,8 @@ This form has a great advantage.
 Read the trio-util_'s documentation for details.
 
 
-run_as_secondary, run_as_daemon
--------------------------------
+run_as_daemon
+-------------
 
 All the APIs explained so far treat tasks equally.
 Taking ``wait_any_cm`` as an example, when either the code within the with-block or the awaitable passed to the API
@@ -144,15 +144,19 @@ But if ``async_fn()`` finishes first, it will cause nothing, and just waits for 
 finish.
 You can think of this as the relation between a non-daemon thread and a daemon thread.
 
+.. note::
 
-run_as_primary
---------------
+    This is an equivalence of :func:`trio_util.run_and_cancelling`.
+
+
+run_as_main
+-----------
 
 The opposite of ``run_as_daemon``.
 
 .. code-block::
 
-    async with run_as_primary(async_fn()):
+    async with run_as_main(async_fn()):
         ...
 
 If ``async_fn()`` finishes first, it will cause the code within the with-block to be cancelled.

--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -8,14 +8,14 @@ __all__ = (
 
     # structured concurrency
     'wait_all', 'wait_any', 'and_', 'or_', 'wait_all_cm', 'wait_any_cm',
-    'run_as_secondary', 'run_as_primary', 'run_as_daemon',
+    'run_as_main', 'run_as_daemon',
     'open_nursery', 'Nursery',
 
     # bridge between async-world and sync-world
     'AsyncBox', 'AsyncEvent',
 
     # deprecated
-    'Event',
+    'Event', 'run_as_primary', 'run_as_secondary',
 )
 import types
 import typing as T
@@ -153,7 +153,7 @@ class Task:
 
     @property
     def finished(self) -> bool:
-        '''Whether the task has been completed..'''
+        '''Whether the task has been completed.'''
         return self._state is TaskState.FINISHED
 
     @property
@@ -811,20 +811,22 @@ The context manager form of :func:`wait_any`, an equivalence of :func:`trio_util
     async with wait_any_cm(async_fn()) as bg_task:
         ...
 '''
-run_as_primary: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_primary()", _on_child_end__ver_any, True)
+run_as_main: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_main()", _on_child_end__ver_any, True)
 '''
 .. code-block::
 
-    async with run_as_primary(async_fn()) as task:
+    async with run_as_main(async_fn()) as task:
         ...
-'''
-run_as_secondary: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_secondary()", _on_child_end__ver_all, False)
-'''
-An equivalent of :func:`trio_util.run_and_cancelling`.
 
+.. note::
+
+    You need to use its older name, ``run_as_primary``, if you are using ``asyncgui`` 0.6.2 or older.
+'''
+run_as_daemon: _wait_xxx_cm_type = partial(_wait_xxx_cm, "run_as_daemon()", _on_child_end__ver_all, False)
+'''
 .. code-block::
 
-    async with run_as_secondary(async_fn()) as bg_task:
+    async with run_as_daemon(async_fn()) as bg_task:
         ...
 '''
 
@@ -935,6 +937,7 @@ async def open_nursery(*, _gc_in_every=1000) -> T.AsyncIterator[Nursery]:
 # -----------------------------------------------------------------------------
 # Aliases
 # -----------------------------------------------------------------------------
-run_as_daemon = run_as_secondary  #: An alias for :func:`run_as_secondary`.
+run_as_primary = run_as_main
+run_as_secondary = run_as_daemon
 and_ = wait_all  #: An alias for :func:`wait_all`.
 or_ = wait_any  #: An alias for :func:`wait_any`.

--- a/tests/test_run_as_daemon.py
+++ b/tests/test_run_as_daemon.py
@@ -12,7 +12,7 @@ def test_bg_finishes_immediately():
         pass
 
     async def async_fn():
-        async with ag.run_as_secondary(finish_imm()) as bg_task:
+        async with ag.run_as_daemon(finish_imm()) as bg_task:
             assert bg_task.finished
 
     fg_task = ag.start(async_fn())
@@ -24,7 +24,7 @@ def test_bg_finishes_while_fg_is_running():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_secondary(ag.sleep_forever()) as bg_task:
+        async with ag.run_as_daemon(ag.sleep_forever()) as bg_task:
             assert bg_task.state is TS.STARTED
             bg_task._step()
             assert bg_task.state is TS.FINISHED
@@ -39,7 +39,7 @@ def test_bg_finishes_while_fg_is_suspended():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_secondary(e.wait()) as bg_task:
+        async with ag.run_as_daemon(e.wait()) as bg_task:
             assert bg_task.state is TS.STARTED
             await ag.sleep_forever()
             assert bg_task.state is TS.FINISHED
@@ -66,7 +66,7 @@ def test_fg_finishes_while_bg_is_running(bg_cancel):
             await ag.sleep_forever()
 
     async def async_fn(e):
-        async with ag.run_as_secondary(bg_fn()) as bg_task:
+        async with ag.run_as_daemon(bg_fn()) as bg_task:
             assert bg_task.state is TS.STARTED
             await ag.sleep_forever()
             assert bg_task.state is TS.STARTED
@@ -84,7 +84,7 @@ def test_fg_finishes_while_bg_is_suspended():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_secondary(ag.sleep_forever()) as bg_task:
+        async with ag.run_as_daemon(ag.sleep_forever()) as bg_task:
             assert bg_task.state is TS.STARTED
         assert bg_task.state is TS.CANCELLED
 
@@ -101,7 +101,7 @@ def test_fg_finishes_while_bg_is_protected():
             await e.wait()
 
     async def async_fn():
-        async with ag.run_as_secondary(bg_func()) as bg_task:
+        async with ag.run_as_daemon(bg_func()) as bg_task:
             assert bg_task.state is TS.STARTED
         assert bg_task.state is TS.FINISHED
 

--- a/tests/test_run_as_main.py
+++ b/tests/test_run_as_main.py
@@ -14,7 +14,7 @@ def test_bg_finishes_immediately(fg_sleep):
         pass
 
     async def async_fn():
-        async with ag.run_as_primary(finish_imm()) as bg_task:
+        async with ag.run_as_main(finish_imm()) as bg_task:
             assert bg_task.finished
             if fg_sleep:
                 await ag.sleep_forever()
@@ -29,7 +29,7 @@ def test_bg_finishes_while_fg_is_running(fg_sleep):
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_primary(ag.sleep_forever()) as bg_task:
+        async with ag.run_as_main(ag.sleep_forever()) as bg_task:
             assert bg_task.state is TS.STARTED
             bg_task._step()
             assert bg_task.state is TS.FINISHED
@@ -46,7 +46,7 @@ def test_bg_finishes_while_fg_is_suspended():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_primary(e.wait()) as bg_task:
+        async with ag.run_as_main(e.wait()) as bg_task:
             assert bg_task.state is TS.STARTED
             await ag.sleep_forever()
             pytest.fail()
@@ -68,7 +68,7 @@ def test_fg_finishes_while_bg_is_running():
         fg_task._step()
 
     async def async_fn():
-        async with ag.run_as_primary(bg_fn()) as bg_task:
+        async with ag.run_as_main(bg_fn()) as bg_task:
             assert bg_task.state is TS.STARTED
             await ag.sleep_forever()
             assert bg_task.state is TS.STARTED
@@ -86,7 +86,7 @@ def test_fg_finishes_while_bg_is_suspended():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_primary(e.wait()) as bg_task:
+        async with ag.run_as_main(e.wait()) as bg_task:
             assert bg_task.state is TS.STARTED
         assert bg_task.state is TS.FINISHED
         
@@ -103,7 +103,7 @@ def test_bg_finishes_while_fg_is_protected():
     TS = ag.TaskState
 
     async def async_fn():
-        async with ag.run_as_primary(e.wait()) as bg_task:
+        async with ag.run_as_main(e.wait()) as bg_task:
             async with ag.disable_cancellation():
                 await ag.sleep_forever()
             assert bg_task.state is TS.FINISHED

--- a/tests/test_wait_xxx_cm.py
+++ b/tests/test_wait_xxx_cm.py
@@ -1,19 +1,19 @@
 import pytest
 
 
-@pytest.fixture(scope='module', params=('wait_all_cm', 'wait_any_cm',  'run_as_secondary', 'run_as_primary', ))
+@pytest.fixture(scope='module', params=('wait_all_cm', 'wait_any_cm',  'run_as_daemon', 'run_as_main', ))
 def any_cm(request):
     import asyncgui
     return getattr(asyncgui, request.param)
 
 
-@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_secondary', ))
+@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_daemon', ))
 def fg_primary_cm(request):
     import asyncgui
     return getattr(asyncgui, request.param)
 
 
-@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_primary', ))
+@pytest.fixture(scope='module', params=('wait_any_cm',  'run_as_main', ))
 def bg_primary_cm(request):
     import asyncgui
     return getattr(asyncgui, request.param)


### PR DESCRIPTION
This only deprecates aliases. APIs still remain.