### PR TITLE
Deprecate `open_cancel_scope()` and `disable_cancellation()`

### DIFF
--- a/sphinx/reference.rst
+++ b/sphinx/reference.rst
@@ -5,4 +5,4 @@ API Reference
    :members:
    :undoc-members:
    :no-show-inheritance:
-   :exclude-members:
+   :exclude-members: disable_cancellation, open_cancel_scope, CancelScope

--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -354,6 +354,8 @@ class open_cancel_scope:
 
         async with open_cancel_scope() as scope:
             ...
+
+    .. deprecated:: 0.8.0
     '''
     __slots__ = ('_scope', )
 
@@ -388,6 +390,9 @@ class disable_cancellation:
 
         async with disable_cancellation():
             await something  # <- never gets cancelled
+
+    .. deprecated:: 0.8.0
+        Disabling cancellation hinders clean-up, so avoid using this API unless absolutely necessary.
     '''
 
     __slots__ = ('_task', )

--- a/tests/wait_all/test_nested_and_protected.py
+++ b/tests/wait_all/test_nested_and_protected.py
@@ -22,28 +22,28 @@ async def main(e1, e2):
 
 
 p = pytest.mark.parametrize
-@p('set_immediately_1', (True, False, ))
-@p('set_immediately_2', (True, False, ))
-def test_nested(set_immediately_1, set_immediately_2):
+@p('fire_immediately_1', (True, False, ))
+@p('fire_immediately_2', (True, False, ))
+def test_nested(fire_immediately_1, fire_immediately_2):
     import asyncgui as ag
     TS = ag.TaskState
 
     e1 = ag.StatefulEvent()
     e2 = ag.StatefulEvent()
-    if set_immediately_1:
+    if fire_immediately_1:
         e1.fire()
-    if set_immediately_2:
+    if fire_immediately_2:
         e2.fire()
 
     main_task = ag.Task(main(e1, e2))
     ag.start(main_task)
     main_task.cancel()
-    if set_immediately_1 and set_immediately_2:
+    if fire_immediately_1 and fire_immediately_2:
         # 中断の機会を与えられずに終わる為 FINISHED
         assert main_task.state is TS.FINISHED
         return
     assert main_task.state is TS.STARTED
-    if set_immediately_1 or set_immediately_2:
+    if fire_immediately_1 or fire_immediately_2:
         e1.fire()
         e2.fire()
         assert main_task.state is TS.CANCELLED

--- a/tests/wait_any/test_nested_and_protected.py
+++ b/tests/wait_any/test_nested_and_protected.py
@@ -22,28 +22,28 @@ async def main(e1, e2):
 
 
 p = pytest.mark.parametrize
-@p('set_immediately_1', (True, False, ))
-@p('set_immediately_2', (True, False, ))
-def test_nested(set_immediately_1, set_immediately_2):
+@p('fire_immediately_1', (True, False, ))
+@p('fire_immediately_2', (True, False, ))
+def test_nested(fire_immediately_1, fire_immediately_2):
     import asyncgui as ag
     TS = ag.TaskState
 
     e1 = ag.StatefulEvent()
     e2 = ag.StatefulEvent()
-    if set_immediately_1:
+    if fire_immediately_1:
         e1.fire()
-    if set_immediately_2:
+    if fire_immediately_2:
         e2.fire()
 
     main_task = ag.Task(main(e1, e2))
     ag.start(main_task)
     main_task.cancel()
-    if set_immediately_1 and set_immediately_2:
+    if fire_immediately_1 and fire_immediately_2:
         # 中断の機会を与えられずに終わる為 FINISHED
         assert main_task.state is TS.FINISHED
         return
     assert main_task.state is TS.STARTED
-    if set_immediately_1 or set_immediately_2:
+    if fire_immediately_1 or fire_immediately_2:
         e1.fire()
         e2.fire()
         assert main_task.state is TS.CANCELLED


### PR DESCRIPTION
### The reason of `open_cancel_scope()` deprecation

`Trio`が持つ機能だから良いものだろうと踏んで用意したが、今思うとかなり低レベルで、かつ多くの場合はより高レベルな`構造化された並行性`系のAPIで代替可能だから。

### The reason of `disable_cancellation()` deprecation

中断できないタスクによりタスクの後始末ができなくなる事が非常に良くないことであるため