### PR TITLE
Add `wait` method variants to `ExclusiveEvent`

### DIFF
--- a/src/asyncgui.py
+++ b/src/asyncgui.py
@@ -423,6 +423,38 @@ class ExclusiveEvent:
     def _attach_task(self, task):
         self._callback = task._step
 
+    @types.coroutine
+    def wait_args(self) -> Generator[YieldType, SendType, tuple]:
+        '''
+        (experimental)
+
+        ``await event.wait_args()`` is equivalent to ``(await event.wait())[0]``.
+
+        :meta private:
+        '''
+        if self._callback is not None:
+            raise InvalidStateError("There's already a task waiting for the event to fire.")
+        try:
+            return (yield self._attach_task)[0]
+        finally:
+            self._callback = None
+
+    @types.coroutine
+    def wait_args_0(self) -> Generator[YieldType, SendType, Any]:
+        '''
+        (experimental)
+
+        ``await event.wait_args_0()`` is equivalent to ``(await event.wait())[0][0]``.
+
+        :meta private:
+        '''
+        if self._callback is not None:
+            raise InvalidStateError("There's already a task waiting for the event to fire.")
+        try:
+            return (yield self._attach_task)[0][0]
+        finally:
+            self._callback = None
+
 
 class Event:
     '''

--- a/tests/test_ExclusiveEvent.py
+++ b/tests/test_ExclusiveEvent.py
@@ -71,3 +71,22 @@ def test_cancel():
     assert task.state is TS.STARTED
     task._step()
     assert task.state is TS.FINISHED
+
+
+def test_wait_args():
+    import asyncgui as ag
+
+    e = ag.ExclusiveEvent()
+    task = ag.start(e.wait_args())
+    assert not task.finished
+    e.fire(1, 2, one='ONE')
+    assert task.result == (1, 2, )
+
+def test_wait_args_0():
+    import asyncgui as ag
+
+    e = ag.ExclusiveEvent()
+    task = ag.start(e.wait_args_0())
+    assert not task.finished
+    e.fire(1, 2, one='ONE')
+    assert task.result == 1


### PR DESCRIPTION
コンテキストマネージャー型の機能の実装に役立つ。

```python
import asyncgui as ag
from contextlib import contextmanager

@contextmanager
def wait_freq():
    e = ag.ExclusiveEvent()
    register_callback(e.fire)
    try:
        yield e.wait_args_0
    finally:
        unregister_callback(e.fire)

async def user_side():
    with wait_freq() as wait:
        while True:
            value = await wait():
            ...
```