### PR TITLE
Nursery: Replace the `daemon` parameter with `role`

### DIFF
--- a/src/asyncgui/__init__.py
+++ b/src/asyncgui/__init__.py
@@ -244,23 +244,18 @@ class Task:
             self._cancel_if_needed()
 
     class CancelScope:
-        __slots__ = ('_task', '_depth', 'cancel_called', )
+        __slots__ = ("_task", "_depth", "done", )
 
         def __init__(self, task, depth):
             self._task = task
             self._depth = depth
-            self.cancel_called = False
-
-        @property
-        def closed(self) -> bool:
-            return self._task is None
+            self.done = False
 
         def cancel(self):
-            if self.cancel_called:
+            if self.done:
                 return
-            self.cancel_called = True
-            if (t := self._task) is not None:
-                t.cancel(self._depth)
+            self.done = True
+            self._task.cancel(self._depth)
 
     @contextmanager
     def _open_cancel_scope(self, CancelScope=CancelScope):
@@ -275,7 +270,7 @@ class Task:
                 raise
         finally:
             req_level = self._requested_cancel_level
-            scope._task = None
+            scope.done = True
             self._current_depth -= 1
             if req_level is not None:
                 if req_level == depth:

--- a/src/asyncgui/__init__.py
+++ b/src/asyncgui/__init__.py
@@ -14,7 +14,7 @@ __all__ = (
     # synchronization
     'Event', 'ExclusiveEvent', 'StatefulEvent', 'StatelessEvent',
 )
-from typing import Any, Union, TypeAlias
+from typing import Any, Union, TypeAlias, Literal
 from collections.abc import (
     Iterable, Coroutine, Awaitable, AsyncIterator, Generator, Callable,
 )
@@ -811,6 +811,14 @@ This is equivalent to :func:`trio_util.move_on_when`.
         print(f"async_fn completed with a return value of {task.result}.")
     else:
         print(f"async_fn was cancelled.")
+
+You can replicate the same behavior with :func:`open_nursery` as follows:
+
+.. code-block::
+
+    async with open_nursery() as nursery:
+        task = nursery.start(async_fn(), role="closer")
+        ...
 '''
 
 
@@ -829,45 +837,68 @@ This is equivalent to :func:`trio_util.run_and_cancelling`.
         print(f"async_fn completed with a return value of {task.result}.")
     else:
         print(f"async_fn was cancelled.")
+
+You can replicate the same behavior with :func:`open_nursery` as follows:
+
+.. code-block::
+
+    async with open_nursery() as nursery:
+        task = nursery.start(async_fn(), role="daemon")
+        ...
 '''
+
+
+TaskRole: TypeAlias = Literal["default", "daemon", "closer"]
 
 
 class Nursery:
     '''
     An equivalent of :class:`trio.Nursery`.
-    You should not directly instantiate this, use :func:`open_nursery`.
+    Do not instantiate this class directly; use :func:`open_nursery`.
+
+    Nursery is closed when any of the following occurs:
+
+    * :meth:`close` is called.
+    * Any child task raises an exception.
+    * Any child task with the "closer" role completes.
+    * All child tasks complete.
+    * Only child tasks with the "daemon" role remain running.
     '''
 
-    __slots__ = ('_closed', '_children', '_scope', '_counters', '_callbacks', '_gc_in_every', '_n_until_gc', )
+    __slots__ = ("_closed", "_children", "_scope", "_role2stuff", "_gc_in_every", "_n_until_gc", )
 
     def __init__(self, scope, counter, daemon_counter, gc_in_every):
         self._gc_in_every = self._n_until_gc = gc_in_every
         self._closed = False
         self._children = []
         self._scope = scope
-        self._counters = (daemon_counter, counter, )
-        self._callbacks = (
-            partial(_close_on_fail, scope, daemon_counter),
-            partial(_close_on_fail, scope, counter),
-        )
+        self._role2stuff = {
+            "daemon": (partial(_close_on_fail, scope, daemon_counter), daemon_counter),
+            "default": (partial(_close_on_fail, scope, counter), counter),
+            "closer": (partial(_close_on_fail_or_finish, scope, counter), counter),
+        }
 
-    def start(self, aw: Aw_or_Task, /, *, daemon=False) -> Task:
+    def start(self, aw: Aw_or_Task, /, *, role: TaskRole="default") -> Task:
         '''
-        *Immediately* start a Task under the supervision of the nursery.
+        *Immediately* starts a Task under the supervision of the nursery.
 
-        The ``daemon`` parameter acts like the one in the :mod:`threading` module.
-        When only daemon tasks are left, they get cancelled, and the nursery closes.
+        .. versionchanged:: 0.11.0
+            The ``role`` parameter replaces the previous ``daemon`` parameter.
         '''
         if self._closed:
             raise InvalidStateError("Nursery has been already closed")
+        try:
+            on_child_end, counter = self._role2stuff[role]
+        except KeyError:
+            raise ValueError(f"Invalid task role: {role}")
         if not self._n_until_gc:
             self._collect_garbage()
             self._n_until_gc = self._gc_in_every
         self._n_until_gc -= 1
         child = aw if isinstance(aw, Task) else Task(aw)
         child._suppresses_exc = True
-        child._on_end = self._callbacks[not daemon]
-        self._counters[not daemon].increase()
+        child._on_end = on_child_end
+        counter.increase()
         self._children.append(child)
         return start(child)
 
@@ -878,7 +909,10 @@ class Nursery:
         ]
 
     def close(self):
-        '''Cancel all the child tasks in the nursery as soon as possible. '''
+        '''
+        Cancels all child tasks in the nursery as soon as possible.
+        After this method is called, no new child tasks can be started.
+        '''
         self._closed = True
         self._scope.cancel()
 
@@ -896,7 +930,7 @@ async def open_nursery(*, _gc_in_every=1000) -> AsyncIterator[Nursery]:
 
         async with open_nursery() as nursery:
             nursery.start(async_fn1())
-            nursery.start(async_fn2(), daemon=True)
+            nursery.start(async_fn2(), role="daemon")
     '''
     exc = None
     parent = await current_task()

--- a/tests/test_cancel_scope.py
+++ b/tests/test_cancel_scope.py
@@ -8,13 +8,11 @@ def test_no_cancel():
         task = await ag.current_task()
         with task._open_cancel_scope() as scope:
             assert scope._depth == 1
-            assert not scope.cancel_called
-            assert not scope.closed
+            assert not scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level is None
         assert scope._depth == 1
-        assert not scope.cancel_called
-        assert scope.closed
+        assert scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -22,29 +20,28 @@ def test_no_cancel():
     assert task.finished
 
 
-def test_cancel():
+@pytest.mark.parametrize("wait_cancel", (True, False, ))
+def test_cancel(wait_cancel):
     import asyncgui as ag
 
     async def async_fn():
         task = await ag.current_task()
         with task._open_cancel_scope() as scope:
             assert scope._depth == 1
-            assert not scope.cancel_called
-            assert not scope.closed
+            assert not scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level is None
             scope.cancel()
             assert scope._depth == 1
-            assert scope.cancel_called
-            assert not scope.closed
+            assert scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level == 1
 
-            await ag.sleep_forever()
-            pytest.fail("Failed to cancel")
+            if wait_cancel:
+                await ag.sleep_forever()
+                pytest.fail("Failed to cancel")
         assert scope._depth == 1
-        assert scope.cancel_called
-        assert scope.closed
+        assert scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -59,33 +56,26 @@ def test_cancel_neither():
         task = await ag.current_task()
         with task._open_cancel_scope() as o_scope:  # o_ -> outer
             assert o_scope._depth == 1
-            assert not o_scope.cancel_called
-            assert not o_scope.closed
+            assert not o_scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level is None
             with task._open_cancel_scope() as i_scope:  # i_ -> inner
                 assert i_scope._depth == 2
-                assert not i_scope.cancel_called
-                assert not i_scope.closed
+                assert not i_scope.done
                 assert o_scope._depth == 1
-                assert not o_scope.cancel_called
-                assert not o_scope.closed
+                assert not o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level is None
             assert i_scope._depth == 2
-            assert not i_scope.cancel_called
-            assert i_scope.closed
+            assert i_scope.done
             assert o_scope._depth == 1
-            assert not o_scope.cancel_called
-            assert not o_scope.closed
+            assert not o_scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level is None
         assert i_scope._depth == 2
-        assert not i_scope.cancel_called
-        assert i_scope.closed
+        assert i_scope.done
         assert o_scope._depth == 1
-        assert not o_scope.cancel_called
-        assert o_scope.closed
+        assert o_scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -102,30 +92,24 @@ def test_cancel_inner():
             with task._open_cancel_scope() as i_scope:
                 i_scope.cancel()
                 assert i_scope._depth == 2
-                assert i_scope.cancel_called
-                assert not i_scope.closed
+                assert i_scope.done
                 assert o_scope._depth == 1
-                assert not o_scope.cancel_called
-                assert not o_scope.closed
+                assert not o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 2
 
                 await ag.sleep_forever()
                 pytest.fail("Failed to cancel")
             assert i_scope._depth == 2
-            assert i_scope.cancel_called
-            assert i_scope.closed
+            assert i_scope.done
             assert o_scope._depth == 1
-            assert not o_scope.cancel_called
-            assert not o_scope.closed
+            assert not o_scope.done
             assert task._current_depth == 1
             assert task._requested_cancel_level is None
         assert i_scope._depth == 2
-        assert i_scope.cancel_called
-        assert i_scope.closed
+        assert i_scope.done
         assert o_scope._depth == 1
-        assert not o_scope.cancel_called
-        assert o_scope.closed
+        assert o_scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -142,11 +126,9 @@ def test_cancel_outer():
             with task._open_cancel_scope() as i_scope:
                 o_scope.cancel()
                 assert i_scope._depth == 2
-                assert not i_scope.cancel_called
-                assert not i_scope.closed
+                assert not i_scope.done
                 assert o_scope._depth == 1
-                assert o_scope.cancel_called
-                assert not o_scope.closed
+                assert o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 1
 
@@ -154,11 +136,9 @@ def test_cancel_outer():
                 pytest.fail("Failed to cancel")
             pytest.fail("Failed to cancel")
         assert i_scope._depth == 2
-        assert not i_scope.cancel_called
-        assert i_scope.closed
+        assert i_scope.done
         assert o_scope._depth == 1
-        assert o_scope.cancel_called
-        assert o_scope.closed
+        assert o_scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -175,20 +155,16 @@ def test_cancel_inner_first():
             with task._open_cancel_scope() as i_scope:
                 i_scope.cancel()
                 assert i_scope._depth == 2
-                assert i_scope.cancel_called
-                assert not i_scope.closed
+                assert i_scope.done
                 assert o_scope._depth == 1
-                assert not o_scope.cancel_called
-                assert not o_scope.closed
+                assert not o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 2
                 o_scope.cancel()
                 assert i_scope._depth == 2
-                assert i_scope.cancel_called
-                assert not i_scope.closed
+                assert i_scope.done
                 assert o_scope._depth == 1
-                assert o_scope.cancel_called
-                assert not o_scope.closed
+                assert o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 1
 
@@ -196,11 +172,9 @@ def test_cancel_inner_first():
                 pytest.fail("Failed to cancel")
             pytest.fail("Failed to cancel")
         assert i_scope._depth == 2
-        assert i_scope.cancel_called
-        assert i_scope.closed
+        assert i_scope.done
         assert o_scope._depth == 1
-        assert o_scope.cancel_called
-        assert o_scope.closed
+        assert o_scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 
@@ -217,20 +191,16 @@ def test_cancel_outer_first():
             with task._open_cancel_scope() as i_scope:
                 o_scope.cancel()
                 assert i_scope._depth == 2
-                assert not i_scope.cancel_called
-                assert not i_scope.closed
+                assert not i_scope.done
                 assert o_scope._depth == 1
-                assert o_scope.cancel_called
-                assert not o_scope.closed
+                assert o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 1
                 i_scope.cancel()
                 assert i_scope._depth == 2
-                assert i_scope.cancel_called
-                assert not i_scope.closed
+                assert i_scope.done
                 assert o_scope._depth == 1
-                assert o_scope.cancel_called
-                assert not o_scope.closed
+                assert o_scope.done
                 assert task._current_depth == 2
                 assert task._requested_cancel_level == 1
 
@@ -238,11 +208,9 @@ def test_cancel_outer_first():
                 pytest.fail("Failed to cancel")
             pytest.fail("Failed to cancel")
         assert i_scope._depth == 2
-        assert i_scope.cancel_called
-        assert i_scope.closed
+        assert i_scope.done
         assert o_scope._depth == 1
-        assert o_scope.cancel_called
-        assert o_scope.closed
+        assert o_scope.done
         assert task._current_depth == 0
         assert task._requested_cancel_level is None
 

--- a/tests/test_nursery.py
+++ b/tests/test_nursery.py
@@ -30,7 +30,7 @@ def test_one_daemon():
     async def async_fn(ctx):
         async with ag.open_nursery() as nursery:
             ctx['nursery'] = nursery
-            ctx['daemon'] = nursery.start(ag.sleep_forever(), daemon=True)
+            ctx['daemon'] = nursery.start(ag.sleep_forever(), role="daemon")
             await ag.sleep_forever()
 
     ctx = {}
@@ -53,7 +53,7 @@ def test_finish_a_child_while_a_daemon_is_alive():
     async def async_fn(ctx):
         async with ag.open_nursery() as nursery:
             ctx['nursery'] = nursery
-            ctx['daemon'] = nursery.start(ag.sleep_forever(), daemon=True)
+            ctx['daemon'] = nursery.start(ag.sleep_forever(), role="daemon")
             ctx['child'] = nursery.start(ag.sleep_forever())
 
     ctx = {}
@@ -79,7 +79,7 @@ def test_cancel_a_child_while_a_daemon_is_alive():
     async def async_fn(ctx):
         async with ag.open_nursery() as nursery:
             ctx['nursery'] = nursery
-            ctx['daemon'] = nursery.start(ag.sleep_forever(), daemon=True)
+            ctx['daemon'] = nursery.start(ag.sleep_forever(), role="daemon")
             ctx['child'] = nursery.start(ag.sleep_forever())
 
     ctx = {}
@@ -112,7 +112,7 @@ def test_finish_a_child_and_a_daemon_fails():
         with pytest.raises(ag.ExceptionGroup) as excinfo:
             async with ag.open_nursery() as nursery:
                 ctx['nursery'] = nursery
-                ctx['daemon'] = nursery.start(fail_eventually(), daemon=True)
+                ctx['daemon'] = nursery.start(fail_eventually(), role="daemon")
                 ctx['child'] = nursery.start(ag.sleep_forever())
             assert [ZeroDivisionError, ] == [type(e) for e in excinfo.value.exceptions]
 
@@ -146,7 +146,7 @@ def test_finish_a_child_and_a_daemon_immediately_fails():
         with pytest.raises(ag.ExceptionGroup) as excinfo:
             async with ag.open_nursery() as nursery:
                 ctx['nursery'] = nursery
-                ctx['daemon'] = nursery.start(fail_imm(), daemon=True)
+                ctx['daemon'] = nursery.start(fail_imm(), role="daemon")
                 ctx['child'] = nursery.start(do_nothing())
                 await ag.sleep_forever()
                 pytest.fail()
@@ -239,8 +239,8 @@ def test_parent_fails():
     async def async_fn():
         with pytest.raises(ag.ExceptionGroup) as excinfo:
             async with ag.open_nursery() as nursery:
-                nursery.start(fail_imm(), daemon=True)
-                nursery.start(fail_eventually(), daemon=True)
+                nursery.start(fail_imm(), role="daemon")
+                nursery.start(fail_eventually(), role="daemon")
                 nursery.start(fail_imm())
                 nursery.start(fail_eventually())
                 raise ZeroDivisionError
@@ -279,3 +279,35 @@ def test_garbage_collection():
     assert len(nursery._children) == 2
     nursery.close()
     assert root.finished
+
+
+def test_invalid_role():
+    import asyncgui as ag
+
+    async def async_fn():
+        async with ag.open_nursery() as nursery:
+            with pytest.raises(ValueError):
+                nursery.start(ag.sleep_forever(), role="???")
+
+    root = ag.start(async_fn())
+    assert root.finished
+
+
+@pytest.mark.parametrize("wait", [True, False])
+def test_closer_task_completes_while_there_are_other_running_tasks(wait):
+    import asyncgui as ag
+    TS = ag.TaskState
+
+    async def async_fn():
+        async with ag.open_nursery() as nursery:
+            nursery.start(ag.sleep_forever(), role="daemon")
+            nursery.start(ag.sleep_forever(), role="default")
+            nursery.start(e.wait(), role="closer")
+            if wait:
+                await ag.sleep_forever()
+
+    e = ag.Event()
+    root = ag.start(async_fn())
+    assert root.state is TS.STARTED
+    e.fire()
+    assert root.state is TS.FINISHED


### PR DESCRIPTION
With this change, you can recreate some of the APIs removed in #159 with little effort.

### run_as_daemons

```python
# version 0.10
async with run_as_daemons(*args) as tasks:
    ...

# version 0.11
async with open_nursery() as nursery:
    tasks = [nursery.start(arg, role="daemon") for arg in args]
    ...
```

### move_on_when_any

```python
# version 0.10
async with move_on_when_any(*args) as tasks:
    ...

# version 0.11
async with open_nursery() as nursery:
    tasks = [nursery.start(arg, role="closer") for arg in args]
    ...
```