### PR TITLE
atomic_step() makes the smallest possible step on suspension of a coroutine

### DIFF
--- a/src/asyncgui/__init__.py
+++ b/src/asyncgui/__init__.py
@@ -634,6 +634,24 @@ class StatefulEvent:
         return p
 
 
+@types.coroutine
+def atomic_step(callback):
+    '''
+    Official interface for making a tightly looped coroutine suspension
+
+    Contrary to any of the event types, this interface makes callbacks and other things more tight.
+
+    The callback is called with a callable, which in turn is intended to be called by the callback as soon
+    as the result is available.
+
+    (example pending)
+
+    The *args and **kwargs used for this are returned after the await as usual for asyncgui Events.
+    '''
+    # noinspection PyProtectedMember
+    return (yield lambda task: callback(task._step))
+
+
 # -----------------------------------------------------------------------------
 # Structured concurrency
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Until now, the several *Event classes are the official interface for creating a asyncgui coroutine.

Sometimes, however, these are not enough or too heavyweight.

Consider, **also as a rationale**, the following situation:

* You want to create a coroutine for launching a user defined (virtual) event.
* This event you want to listen on.
* The event is fired with a callback mechanism which might be called as soon as you install it.
* Then the event might be fired before you have the opportunity to await it.

### Example:

```python
async def tk_event_future(widget, future):
    """Callback based event triggering via Tkinter events.

    This is suggested in https://tkdocs.com/tutorial/eventloop.html#threads.

    But it seems that the other way to go is as safe as this one."""
    event_name = '<<WaitForFuture-%x-%x>>' % (id(widget), id(future))
    with asynctkinter2.event_freq(widget, event_name) as freq:
        future.add_done_callback(lambda fut: widget.event_generate(event_name))
        if not future.done():
            await freq()
            assert future.done()
    return future.result(timeout=0)
```

If the future is already set, future.add_done_callback(...) calls its callback immediately in the current thread, generating a Tkinter event in the UI thread and causing it to be thrown. We have bound the event_freq() event to that Tkinter event, but awaiting on it waits indefinitely, as it is stateless. That's why we have to check future.done() before.

But wouldn't it be fine if we could write it much easier?

An alternative, tighter, less race-condition-prone variant could be:

```python
async def tk_event_future(widget, future):
    """Callback based event triggering via Tkinter events.

    This is suggested in https://tkdocs.com/tutorial/eventloop.html#threads.

    But it seems that the other way to go is as safe as this one."""
    event_name = '<<WaitForFuture-%x-%x>>' % (id(widget), id(future))

    def install_eventhandler(step):
        widget.bind(event_name, step, "+")
        future.add_done_callback(lambda fut: widget.event_generate(event_name))

    try:
        await atomic_step(install_eventhandler)
        assert future.done()
    finally:
        widget.unbind(event_name)
    return future.result()
```

(Yes, I am aware that these are again 12 lines of code instead of 7 lines as in the example above, but  on the other side I don't have to think of every corner case which could happen.)

This is directly above the level of calling task._step, with the difference that it does not rely on task._step, which would be internal to task.

Instead, it uses the new atomic_step() function, which does this step in an atomic way as well.

In this example, it awaits on whatever is initiated by install_eventhandler(). This function binds the given event name to the callback function step which is passed to it and then adds a done callback to the future - which, again, might immedately fire if the future is completed. This doesn't matter, as in this case, the coroutine immediately proceeds where it is without waiting.

I surely could make another example if needed, but this one is the closest I can go at the moment.

An alternative implementation would have been to directly use the return (yield ...) notation, but in this case, the user would need to use task._step, a function which is semantically internal to the task class. Calling it would volate this internal-ness and lead to warnings in the one or other IDE.

(As in the last PR, just tell me if you find the idea worthwhile to be followed or if you think that it still exposes too many internals. If you don't consider the idea good, I'll redraw it.)