### PR TITLE
Create wait_args() and wait_args_0() for all Event classes

### DIFF
--- a/src/asyncgui/__init__.py
+++ b/src/asyncgui/__init__.py
@@ -14,7 +14,7 @@ __all__ = (
     # synchronization
     'Event', 'ExclusiveEvent', 'StatefulEvent', 'StatelessEvent',
 )
-from typing import Any, Union, TypeAlias
+from typing import Any, Union, TypeAlias, Tuple
 from collections.abc import (
     Iterable, Coroutine, Awaitable, AsyncIterator, Generator, Callable,
 )
@@ -525,6 +525,26 @@ class Event:
         finally:
             tasks[idx] = None
 
+    async def wait_args(self) -> Tuple[Any]:
+        '''
+        (experimental)
+
+        ``await event.wait_args()`` is equivalent to ``(await event.wait())[0]``.
+
+        :meta private:
+        '''
+        return (await self.wait())[0]
+
+    async def wait_args_0(self) -> Any:
+        '''
+        (experimental)
+
+        ``await event.wait_args_0()`` is equivalent to ``(await event.wait())[0][0]``.
+
+        :meta private:
+        '''
+        return (await self.wait())[0][0]
+
 
 StatelessEvent = Event
 '''
@@ -606,6 +626,26 @@ class StatefulEvent:
             return (yield tasks.append)
         finally:
             tasks[idx] = None
+
+    async def wait_args(self) -> Tuple[Any]:
+        '''
+        (experimental)
+
+        ``await event.wait_args()`` is equivalent to ``(await event.wait())[0]``.
+
+        :meta private:
+        '''
+        return (await self.wait())[0]
+
+    async def wait_args_0(self) -> Any:
+        '''
+        (experimental)
+
+        ``await event.wait_args_0()`` is equivalent to ``(await event.wait())[0][0]``.
+
+        :meta private:
+        '''
+        return (await self.wait())[0][0]
 
     @property
     def params(self) -> tuple:


### PR DESCRIPTION
In the current code, there is an ExclusiveEvent which, besides its wait(), also has wait_args() and wait_args_0(). While wait() returns a tuple with the args and kwargs provided to _step, wait_args() only returns the args (so [0] of the aforementionned tuple) and wait_args_0() returns only the first arg.

These functions are handy for ExclusiveEvent and also for (Stateless)Event and StatefulEvent.